### PR TITLE
(update) main.css

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -177,9 +177,9 @@ img {
   /* border-radius: 50%; */
   margin-left: -50%;
   display: inline-block;
-  /* box-shadow: 0 0 8px rgba(0, 0, 0, .8); */
+  /* box-shadow: 0 0 8px rgba(0, 0, 0, .8);
   -webkit-box-shadow: 0 0 5px rgba(0, 0, 0, .8);
-  -moz-box-shadow: 0 0 8px rgba(0, 0, 0, .8);
+  -moz-box-shadow: 0 0 8px rgba(0, 0, 0, .8); */
 }
 .navbar-custom .avatar-container .avatar-img {
   width: 100%;
@@ -199,9 +199,9 @@ img {
 
   .navbar-custom .avatar-container .avatar-img-border {
     width: 100%;
-    box-shadow: 1px 1px 2px rgba(0, 0, 0, .8);
+    /* box-shadow: 1px 1px 2px rgba(0, 0, 0, .8);
     -webkit-box-shadow: 1px 1px 2px rgba(0, 0, 0, .8);
-    -moz-box-shadow: 1px 1px 2px rgba(0, 0, 0, .8);
+    -moz-box-shadow: 1px 1px 2px rgba(0, 0, 0, .8); */
   }
 
   .navbar-custom .avatar-container .avatar-img {


### PR DESCRIPTION
## Summary
- This PR removes the box shadow on the main avatar image. 

| Before | After |
|---|---|
![Screen Shot 2019-12-08 at 11 39 11 AM](https://user-images.githubusercontent.com/2600393/70395025-8506ad80-19af-11ea-8ffc-d0fa17627561.png) | ![Screen Shot 2019-12-08 at 11 39 04 AM](https://user-images.githubusercontent.com/2600393/70395020-8041f980-19af-11ea-968f-edd6119ea292.png) 


__Changes:__
- comment out avatar-img-border box shadow styles for mobile and desktop in `main.css`
